### PR TITLE
Added support for zone management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 lib/alljoyn_java.dll
 lib/slf4j-simple-1.7.21.jar
 src/main/java/allplay/
+.gradle/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 .settings/
 bin/
 build/
+.classpath
+.project
+lib/alljoyn_java.dll
+lib/slf4j-simple-1.7.21.jar
+src/main/java/allplay/

--- a/src/main/java/de/kaizencode/tchaikovsky/bus/SpeakerBusHandler.java
+++ b/src/main/java/de/kaizencode/tchaikovsky/bus/SpeakerBusHandler.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import de.kaizencode.tchaikovsky.businterface.MCUInterface;
 import de.kaizencode.tchaikovsky.businterface.MediaPlayerInterface;
 import de.kaizencode.tchaikovsky.businterface.VolumeInterface;
+import de.kaizencode.tchaikovsky.businterface.ZoneManagerInterface;
 import de.kaizencode.tchaikovsky.bussignal.MediaPlayerSignalHandler;
 import de.kaizencode.tchaikovsky.bussignal.SpeakerChangedListener;
 import de.kaizencode.tchaikovsky.exception.ConnectionException;
@@ -172,7 +173,7 @@ public class SpeakerBusHandler {
 
     private ProxyBusObject getProxyBusObject() {
         ProxyBusObject proxyBusObject = busAttachment.getProxyBusObject(speakerBusName, OBJECT_PATH, sessionId.value,
-                new Class<?>[] { MediaPlayerInterface.class, VolumeInterface.class, MCUInterface.class });
+                new Class<?>[] { MediaPlayerInterface.class, VolumeInterface.class, ZoneManagerInterface.class, MCUInterface.class });
         logger.debug("Created ProxyBusObject BusName [" + proxyBusObject.getBusName() + "], object path ["
                 + proxyBusObject.getObjPath() + "]");
         return proxyBusObject;

--- a/src/main/java/de/kaizencode/tchaikovsky/businterface/ZoneManagerInterface.java
+++ b/src/main/java/de/kaizencode/tchaikovsky/businterface/ZoneManagerInterface.java
@@ -1,0 +1,50 @@
+/**
+ * Tchaikovsky - A Java library for controlling AllPlay-compatible devices.
+ * Copyright (c) 2016 Dominic Lerbs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.kaizencode.tchaikovsky.businterface;
+
+import org.alljoyn.bus.BusException;
+import org.alljoyn.bus.annotation.BusInterface;
+import org.alljoyn.bus.annotation.BusMethod;
+import org.alljoyn.bus.annotation.BusProperty;
+import org.alljoyn.bus.annotation.BusSignal;
+
+import de.kaizencode.tchaikovsky.speaker.PlaylistItem;
+import de.kaizencode.tchaikovsky.speaker.remote.RemotePlaylist;
+import de.kaizencode.tchaikovsky.speaker.remote.RemoteVolumeRange;
+import de.kaizencode.tchaikovsky.speaker.remote.RemoteZoneItem;
+
+/**
+ * {@link BusInterface} for <code>net.allplay.ZoneManager</code> interface.
+ * 
+ * @author Yannic Wilkening
+ */
+@BusInterface(name = "net.allplay.ZoneManager")
+public interface ZoneManagerInterface {
+
+    @BusProperty
+    public boolean getEnabled() throws BusException;
+    
+    @BusProperty
+    public short getVersion() throws BusException;
+
+    @BusMethod(name = "CreateZone", signature = "as", replySignature = "sia{si}")
+    public RemoteZoneItem createZone(String[] speakers) throws BusException;
+    
+    //@BusSignal(name = "OnZoneChanged")
+    //public void onZoneChanged(short volume) throws BusException;
+
+}

--- a/src/main/java/de/kaizencode/tchaikovsky/businterface/ZoneManagerInterface.java
+++ b/src/main/java/de/kaizencode/tchaikovsky/businterface/ZoneManagerInterface.java
@@ -16,15 +16,15 @@
  */
 package de.kaizencode.tchaikovsky.businterface;
 
+
+import java.util.Map;
+
 import org.alljoyn.bus.BusException;
 import org.alljoyn.bus.annotation.BusInterface;
 import org.alljoyn.bus.annotation.BusMethod;
 import org.alljoyn.bus.annotation.BusProperty;
 import org.alljoyn.bus.annotation.BusSignal;
 
-import de.kaizencode.tchaikovsky.speaker.PlaylistItem;
-import de.kaizencode.tchaikovsky.speaker.remote.RemotePlaylist;
-import de.kaizencode.tchaikovsky.speaker.remote.RemoteVolumeRange;
 import de.kaizencode.tchaikovsky.speaker.remote.RemoteZoneItem;
 
 /**
@@ -44,7 +44,7 @@ public interface ZoneManagerInterface {
     @BusMethod(name = "CreateZone", signature = "as", replySignature = "sia{si}")
     public RemoteZoneItem createZone(String[] speakers) throws BusException;
     
-    //@BusSignal(name = "OnZoneChanged")
-    //public void onZoneChanged(short volume) throws BusException;
-
+    @BusSignal(name = "OnZoneChanged")
+    public void onZoneChanged(String zoneId, int timestamp, Map<String,Integer> slaves) throws BusException;
+    
 }

--- a/src/main/java/de/kaizencode/tchaikovsky/bussignal/MediaPlayerSignalHandler.java
+++ b/src/main/java/de/kaizencode/tchaikovsky/bussignal/MediaPlayerSignalHandler.java
@@ -44,6 +44,7 @@ public class MediaPlayerSignalHandler {
     private final Map<String, List<SpeakerChangedListener>> speakerChangedListeners = new HashMap<>();
     private static final String MEDIA_PLAYER_INTERFACE = "de.kaizencode.tchaikovsky.businterface.MediaPlayerInterface";
     private static final String VOLUME_INTERFACE = "de.kaizencode.tchaikovsky.businterface.VolumeInterface";
+    private static final String ZONEMANAGER_INTERFACE = "de.kaizencode.tchaikovsky.businterface.ZoneManagerInterface";
 
     private final BusAttachment busAttachment;
 
@@ -155,7 +156,15 @@ public class MediaPlayerSignalHandler {
             listener.onVolumeControlChanged(enabled);
         }
     }
-
+   
+    @BusSignalHandler(iface = ZONEMANAGER_INTERFACE, signal = "onZoneChanged")
+    public void onZoneChanged(String zoneId, int timestamp, Map<String,Integer> slaves) {
+        logSignalReceived("Zone changed");
+        for (SpeakerChangedListener listener : findListeners()) {
+            listener.onZoneChanged(zoneId, timestamp, slaves);
+        }
+    }
+    
     private List<SpeakerChangedListener> findListeners() {
         String busName = busAttachment.getMessageContext().sender;
         if (speakerChangedListeners.containsKey(busName)) {

--- a/src/main/java/de/kaizencode/tchaikovsky/bussignal/SpeakerChangedListener.java
+++ b/src/main/java/de/kaizencode/tchaikovsky/bussignal/SpeakerChangedListener.java
@@ -16,6 +16,8 @@
  */
 package de.kaizencode.tchaikovsky.bussignal;
 
+import java.util.Map;
+
 import de.kaizencode.tchaikovsky.speaker.PlayState;
 import de.kaizencode.tchaikovsky.speaker.Speaker;
 import de.kaizencode.tchaikovsky.speaker.Speaker.LoopMode;
@@ -68,5 +70,15 @@ public interface SpeakerChangedListener {
      *            True if the volume control has been enabled, false if it has been disabled
      */
     public void onVolumeControlChanged(boolean enabled);
-
+    
+    /**
+     * @param zoneId
+     *            The new zone id of the speaker
+     * @param timestamp
+     *            The timestamp of the speaker
+     * @param slaves
+     *            The slaves of the speaker
+     */
+    public void onZoneChanged(String zoneId, int timestamp, Map<String,Integer> slaves);
+    
 }

--- a/src/main/java/de/kaizencode/tchaikovsky/speaker/PlayerInfo.java
+++ b/src/main/java/de/kaizencode/tchaikovsky/speaker/PlayerInfo.java
@@ -32,6 +32,6 @@ public interface PlayerInfo {
 
     int getMaxVolume();
 
-    // ZoneInfo getZoneInfo();
+    ZoneInfo getZoneInfo();
 
 }

--- a/src/main/java/de/kaizencode/tchaikovsky/speaker/Speaker.java
+++ b/src/main/java/de/kaizencode/tchaikovsky/speaker/Speaker.java
@@ -266,6 +266,24 @@ public interface Speaker {
      * @return The {@link Volume} of the speaker.
      */
     Volume volume();
+    
+    /**
+     * Group speakers with {@link ZoneManager} of the speaker.
+     * 
+     * @param speakerItems
+     *            A list of speakers {@link Speaker} to group with the speaker
+     * @throws SpeakerException
+     *             if the {@link ZoneManager} group speakers failed
+     */
+    void createZone(List<Speaker> speakerItems) throws SpeakerException;
+    
+    /**
+     * {@link ZoneManager} release currently grouped slaves of speaker.
+     * 
+     * @throws SpeakerException
+     *             if the {@link ZoneManager} could not release the slaves
+     */
+    void releaseZone() throws SpeakerException;
 
     /**
      * Adds a listener which is notified when the state of the speaker changes.

--- a/src/main/java/de/kaizencode/tchaikovsky/speaker/Speaker.java
+++ b/src/main/java/de/kaizencode/tchaikovsky/speaker/Speaker.java
@@ -268,22 +268,9 @@ public interface Speaker {
     Volume volume();
     
     /**
-     * Group speakers with {@link ZoneManager} of the speaker.
-     * 
-     * @param speakerItems
-     *            A list of speakers {@link Speaker} to group with the speaker
-     * @throws SpeakerException
-     *             if the {@link ZoneManager} group speakers failed
+     * @return The {@link ZoneManager} of the speaker.
      */
-    void createZone(List<Speaker> speakerItems) throws SpeakerException;
-    
-    /**
-     * {@link ZoneManager} release currently grouped slaves of speaker.
-     * 
-     * @throws SpeakerException
-     *             if the {@link ZoneManager} could not release the slaves
-     */
-    void releaseZone() throws SpeakerException;
+    ZoneManager zoneManager();
 
     /**
      * Adds a listener which is notified when the state of the speaker changes.

--- a/src/main/java/de/kaizencode/tchaikovsky/speaker/ZoneInfo.java
+++ b/src/main/java/de/kaizencode/tchaikovsky/speaker/ZoneInfo.java
@@ -23,10 +23,24 @@ package de.kaizencode.tchaikovsky.speaker;
  */
 public interface ZoneInfo {
 
+    /**
+     * @return The current zone id
+     */
     String getZoneId();
 
+    /**
+     * @return The current zone timestamp
+     */
     int getZoneTimestamp();
 
-    // void getLeadPlayerName();
+    /**
+     * @return If the speaker is lead player within the zone
+     */
+    boolean isLeadPlayer();
+    
+    /**
+     * @return The id of the speaker id of the lead player if speaker is not lead
+     */
+    String getLeadPlayerID();
 
 }

--- a/src/main/java/de/kaizencode/tchaikovsky/speaker/ZoneItem.java
+++ b/src/main/java/de/kaizencode/tchaikovsky/speaker/ZoneItem.java
@@ -1,0 +1,35 @@
+/**
+ * Tchaikovsky - A Java library for controlling AllPlay-compatible devices.
+ * Copyright (c) 2016 Dominic Lerbs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.kaizencode.tchaikovsky.speaker;
+
+import java.util.Map;
+
+/**
+ * Information about created zone
+ * 
+ * @author Yannic Wilkening
+ */
+
+public interface ZoneItem {
+    
+    String getZoneId();
+
+    int getZoneTimestamp();
+
+    Map<String,Integer> getSlaves();
+
+}

--- a/src/main/java/de/kaizencode/tchaikovsky/speaker/ZoneManager.java
+++ b/src/main/java/de/kaizencode/tchaikovsky/speaker/ZoneManager.java
@@ -16,8 +16,9 @@
  */
 package de.kaizencode.tchaikovsky.speaker;
 
+import java.util.List;
+
 import de.kaizencode.tchaikovsky.exception.SpeakerException;
-import de.kaizencode.tchaikovsky.speaker.remote.RemoteZoneItem;
 
 /**
  * Group control of the speaker.
@@ -41,12 +42,20 @@ public interface ZoneManager {
     public short getVersion() throws SpeakerException;
 
     /**
-     * @return The {@link RemoteZoneItem} of the speaker.
+     * @return The {@link ZoneItem} of the speaker.
      * @param speakers
      *          Array of {@link Speaker} to add to the group
      * @throws SpeakerException
      *             if the group could not be created
      */
-    public RemoteZoneItem createZone(String[] speakers) throws SpeakerException;
+    public ZoneItem createZone(List<Speaker> speakerItems) throws SpeakerException;
+       
+    /**
+     * {@link ZoneManager} release currently grouped slaves of speaker.
+     * 
+     * @throws SpeakerException
+     *             if the {@link ZoneManager} could not release the slaves
+     */
+    public void releaseZone() throws SpeakerException;
 
 }

--- a/src/main/java/de/kaizencode/tchaikovsky/speaker/ZoneManager.java
+++ b/src/main/java/de/kaizencode/tchaikovsky/speaker/ZoneManager.java
@@ -1,0 +1,52 @@
+/**
+ * Tchaikovsky - A Java library for controlling AllPlay-compatible devices.
+ * Copyright (c) 2016 Dominic Lerbs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.kaizencode.tchaikovsky.speaker;
+
+import de.kaizencode.tchaikovsky.exception.SpeakerException;
+import de.kaizencode.tchaikovsky.speaker.remote.RemoteZoneItem;
+
+/**
+ * Group control of the speaker.
+ * 
+ * @author Yannic Wilkening
+ */
+public interface ZoneManager {
+    
+    /**
+     * @return Enable state of {@link ZoneManager}.
+     * @throws SpeakerException
+     *             if the enable state could not be retrieved
+     */    
+    public boolean getEnabled() throws SpeakerException;
+    
+    /**
+     * @return Version of {@link ZoneManager}.
+     * @throws SpeakerException
+     *             if the version could not be retrieved
+     */
+    public short getVersion() throws SpeakerException;
+
+    /**
+     * @return The {@link RemoteZoneItem} of the speaker.
+     * @param speakers
+     *          Array of {@link Speaker} to add to the group
+     * @throws SpeakerException
+     *             if the group could not be created
+     */
+    public RemoteZoneItem createZone(String[] speakers) throws SpeakerException;
+
+}

--- a/src/main/java/de/kaizencode/tchaikovsky/speaker/remote/RemotePlayerInfo.java
+++ b/src/main/java/de/kaizencode/tchaikovsky/speaker/remote/RemotePlayerInfo.java
@@ -23,6 +23,7 @@ import org.alljoyn.bus.annotation.Position;
 import org.alljoyn.bus.annotation.Signature;
 
 import de.kaizencode.tchaikovsky.speaker.PlayerInfo;
+import de.kaizencode.tchaikovsky.speaker.ZoneInfo;
 
 public class RemotePlayerInfo implements PlayerInfo {
 
@@ -57,10 +58,10 @@ public class RemotePlayerInfo implements PlayerInfo {
         return maxVolume;
     }
 
-    // @Override
-    // public ZoneInfo getZoneInfo() {
-    // return zoneInfo;
-    // }
+    @Override
+    public ZoneInfo getZoneInfo() {
+        return zoneInfo;
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/de/kaizencode/tchaikovsky/speaker/remote/RemoteSpeaker.java
+++ b/src/main/java/de/kaizencode/tchaikovsky/speaker/remote/RemoteSpeaker.java
@@ -29,6 +29,7 @@ import de.kaizencode.tchaikovsky.bus.SpeakerSessionListener;
 import de.kaizencode.tchaikovsky.businterface.MCUInterface;
 import de.kaizencode.tchaikovsky.businterface.MediaPlayerInterface;
 import de.kaizencode.tchaikovsky.businterface.VolumeInterface;
+import de.kaizencode.tchaikovsky.businterface.ZoneManagerInterface;
 import de.kaizencode.tchaikovsky.bussignal.SpeakerChangedListener;
 import de.kaizencode.tchaikovsky.exception.ConnectionException;
 import de.kaizencode.tchaikovsky.exception.SpeakerException;
@@ -36,6 +37,7 @@ import de.kaizencode.tchaikovsky.speaker.PlaylistItem;
 import de.kaizencode.tchaikovsky.speaker.Speaker;
 import de.kaizencode.tchaikovsky.speaker.SpeakerDetails;
 import de.kaizencode.tchaikovsky.speaker.Volume;
+import de.kaizencode.tchaikovsky.speaker.ZoneManager;
 
 public class RemoteSpeaker implements Speaker, SpeakerConnectionListener {
 
@@ -52,6 +54,7 @@ public class RemoteSpeaker implements Speaker, SpeakerConnectionListener {
 
     private final SpeakerDetails details;
     private Volume volume;
+    private ZoneManager zoneManager;
 
     public RemoteSpeaker(SpeakerBusHandler bus, SpeakerDetails details) {
         this.busHandler = bus;
@@ -86,6 +89,7 @@ public class RemoteSpeaker implements Speaker, SpeakerConnectionListener {
 
         mediaPlayerInterface = allPlayObject.getInterface(MediaPlayerInterface.class);
         volume = new RemoteVolume(allPlayObject.getInterface(VolumeInterface.class));
+        zoneManager = new RemoteZoneManager(allPlayObject.getInterface(ZoneManagerInterface.class));
         mcuInterface = allPlayObject.getInterface(MCUInterface.class);
 
         // For an unknown reason, it is necessary to perform at least one method call
@@ -131,7 +135,23 @@ public class RemoteSpeaker implements Speaker, SpeakerConnectionListener {
     public Volume volume() {
         return volume;
     }
+    
+    @Override
+    public void createZone(List<Speaker> speakerItems) throws SpeakerException {
+        String[] speakerArray = new String[speakerItems.size()];
+        
+        for(int i=0; i < speakerItems.size(); i++) {
+            speakerArray[i] = "net.allplay.MediaPlayer.i" + speakerItems.get(i).getId();
+        }
+        
+        zoneManager.createZone(speakerArray);      
+    }
 
+    @Override
+    public void releaseZone() throws SpeakerException {
+        zoneManager.createZone(new String[]{""});        
+    }
+    
     @Override
     public RemotePlayerInfo getPlayerInfo() throws SpeakerException {
         try {

--- a/src/main/java/de/kaizencode/tchaikovsky/speaker/remote/RemoteSpeaker.java
+++ b/src/main/java/de/kaizencode/tchaikovsky/speaker/remote/RemoteSpeaker.java
@@ -137,21 +137,10 @@ public class RemoteSpeaker implements Speaker, SpeakerConnectionListener {
     }
     
     @Override
-    public void createZone(List<Speaker> speakerItems) throws SpeakerException {
-        String[] speakerArray = new String[speakerItems.size()];
-        
-        for(int i=0; i < speakerItems.size(); i++) {
-            speakerArray[i] = "net.allplay.MediaPlayer.i" + speakerItems.get(i).getId();
-        }
-        
-        zoneManager.createZone(speakerArray);      
+    public ZoneManager zoneManager() {
+        return zoneManager;
     }
-
-    @Override
-    public void releaseZone() throws SpeakerException {
-        zoneManager.createZone(new String[]{""});        
-    }
-    
+       
     @Override
     public RemotePlayerInfo getPlayerInfo() throws SpeakerException {
         try {

--- a/src/main/java/de/kaizencode/tchaikovsky/speaker/remote/RemoteZoneInfo.java
+++ b/src/main/java/de/kaizencode/tchaikovsky/speaker/remote/RemoteZoneInfo.java
@@ -16,13 +16,8 @@
  */
 package de.kaizencode.tchaikovsky.speaker.remote;
 
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.TreeMap;
-
 import org.alljoyn.bus.BusException;
 import org.alljoyn.bus.Variant;
-import org.alljoyn.bus.VariantTypeReference;
 import org.alljoyn.bus.annotation.Position;
 import org.alljoyn.bus.annotation.Signature;
 
@@ -52,29 +47,32 @@ public class RemoteZoneInfo implements ZoneInfo {
         return zoneTimestamp;
     }
 
-    // @Override
-    public void getLeadPlayerName() {
+    @Override
+    public boolean isLeadPlayer() {
         try {
             if ("s".equals(leadPlayerName.getSignature())) {
-                System.out.println("leadPlayerName " + leadPlayerName.getObject(String.class));
-            } else if ("a{si}".equals(leadPlayerName.getSignature())) {
-                Map<String, Integer> map = leadPlayerName
-                        .getObject(new VariantTypeReference<TreeMap<String, Integer>>() {
-                        });
-                System.out.println("Size: " + map.size());
-                for (Entry<String, Integer> entry : map.entrySet()) {
-                    System.out.println("String: " + entry.getKey() + ", " + entry.getValue());
-                }
-            } else {
-                System.out.println("Signature: " + leadPlayerName.getSignature());
+                return false;
             }
         } catch (BusException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
         }
-        // return leadPlayerName;
+        return true;
     }
 
+    @Override
+    public String getLeadPlayerID() {
+        try {
+            if ("s".equals(leadPlayerName.getSignature())) {
+                return leadPlayerName.getObject(String.class).replaceAll("net.allplay.MediaPlayer.i", "");
+            }
+        } catch (BusException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+        return null;
+    }
+    
     @Override
     public String toString() {
         return zoneId + "-" + zoneTimestamp + "-" + leadPlayerName;

--- a/src/main/java/de/kaizencode/tchaikovsky/speaker/remote/RemoteZoneItem.java
+++ b/src/main/java/de/kaizencode/tchaikovsky/speaker/remote/RemoteZoneItem.java
@@ -1,0 +1,55 @@
+/**
+ * Tchaikovsky - A Java library for controlling AllPlay-compatible devices.
+ * Copyright (c) 2016 Dominic Lerbs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.kaizencode.tchaikovsky.speaker.remote;
+
+import java.util.Map;
+
+import org.alljoyn.bus.annotation.Position;
+import org.alljoyn.bus.annotation.Signature;
+
+import de.kaizencode.tchaikovsky.speaker.ZoneItem;
+
+public class RemoteZoneItem implements ZoneItem {
+    
+    @Position(0)
+    @Signature("s")
+    public String zoneId;
+
+    @Position(1)
+    @Signature("i")
+    public int zoneTimestamp;
+
+    @Position(2)
+    @Signature("a{si}")
+    public Map<String,Integer> slaves;
+
+    @Override
+    public String getZoneId() {
+        return zoneId;
+    }
+
+    @Override
+    public int getZoneTimestamp() {
+        return zoneTimestamp;
+    }
+    
+    @Override
+    public Map<String,Integer> getSlaves() {
+        return slaves;
+    }
+
+}

--- a/src/main/java/de/kaizencode/tchaikovsky/speaker/remote/RemoteZoneManager.java
+++ b/src/main/java/de/kaizencode/tchaikovsky/speaker/remote/RemoteZoneManager.java
@@ -1,0 +1,64 @@
+/**
+ * Tchaikovsky - A Java library for controlling AllPlay-compatible devices.
+ * Copyright (c) 2016 Dominic Lerbs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.kaizencode.tchaikovsky.speaker.remote;
+
+import org.alljoyn.bus.BusException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.kaizencode.tchaikovsky.businterface.ZoneManagerInterface;
+import de.kaizencode.tchaikovsky.speaker.ZoneManager;
+import de.kaizencode.tchaikovsky.exception.SpeakerException;
+
+public class RemoteZoneManager implements ZoneManager {
+    
+    private final Logger logger = LoggerFactory.getLogger(RemoteVolume.class);
+    private final ZoneManagerInterface zoneManagerInterface;
+
+    public RemoteZoneManager(ZoneManagerInterface zoneManagerInterface) {
+        this.zoneManagerInterface = zoneManagerInterface;
+    }
+
+    @Override
+    public boolean getEnabled() throws SpeakerException {
+        try {
+            return zoneManagerInterface.getEnabled();
+        } catch (BusException e) {
+            throw new SpeakerException("Unable to receive enabled", e);
+        }
+    }
+
+    @Override
+    public short getVersion() throws SpeakerException {
+        try {
+            return zoneManagerInterface.getVersion();
+        } catch (BusException e) {
+            throw new SpeakerException("Unable to receive version", e);
+        }
+    }
+
+    @Override
+    public RemoteZoneItem createZone(String[] speakers) throws SpeakerException {
+        logger.debug("Try to create zone " + speakers.toString());
+        try {
+            return zoneManagerInterface.createZone(speakers);
+        } catch (BusException e) {
+            throw new SpeakerException("Unable to create zone", e);
+        }
+    }
+
+}

--- a/src/main/java/de/kaizencode/tchaikovsky/speaker/remote/RemoteZoneManager.java
+++ b/src/main/java/de/kaizencode/tchaikovsky/speaker/remote/RemoteZoneManager.java
@@ -16,17 +16,19 @@
  */
 package de.kaizencode.tchaikovsky.speaker.remote;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.alljoyn.bus.BusException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import de.kaizencode.tchaikovsky.businterface.ZoneManagerInterface;
+import de.kaizencode.tchaikovsky.speaker.Speaker;
+import de.kaizencode.tchaikovsky.speaker.ZoneItem;
 import de.kaizencode.tchaikovsky.speaker.ZoneManager;
 import de.kaizencode.tchaikovsky.exception.SpeakerException;
 
 public class RemoteZoneManager implements ZoneManager {
     
-    private final Logger logger = LoggerFactory.getLogger(RemoteVolume.class);
     private final ZoneManagerInterface zoneManagerInterface;
 
     public RemoteZoneManager(ZoneManagerInterface zoneManagerInterface) {
@@ -52,13 +54,22 @@ public class RemoteZoneManager implements ZoneManager {
     }
 
     @Override
-    public RemoteZoneItem createZone(String[] speakers) throws SpeakerException {
-        logger.debug("Try to create zone " + speakers.toString());
+    public ZoneItem createZone(List<Speaker> speakerItems) throws SpeakerException {
         try {
+            String[] speakers = new String[speakerItems.size()];
+            for(int i=0; i < speakerItems.size(); i++) {
+                speakers[i] = "net.allplay.MediaPlayer.i" + speakerItems.get(i).getId();
+            }
+            
             return zoneManagerInterface.createZone(speakers);
         } catch (BusException e) {
             throw new SpeakerException("Unable to create zone", e);
         }
+    }
+    
+    @Override
+    public void releaseZone() throws SpeakerException {
+        createZone(new ArrayList<Speaker>());  
     }
 
 }


### PR DESCRIPTION
Hi,

i have added support for ZoneManagement to the tchaikovsky lib.
Just call .createZone() one the desired speaker and pass a list of speaker objects to add to the zone. Afterwards the speaker object you called with .createZone() will become the zone master and all speakers in the passed list will become slaves. 

To revoke the group just call .releaseZone() on the master speaker. 

Code is tested and works just fine for me. Maybe it is a useful feature you would like to pull into your branch.  
